### PR TITLE
Remove Preview designation in extension manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"version": "0.1.1",
 	"license": "MIT",
 	"publisher": "1Password",
-	"preview": true,
 	"icon": "logo.png",
 	"main": "./dist/extension.js",
 	"repository": {


### PR DESCRIPTION
This PR simply removes the "preview" designation from the extension manifest so it will not be listed as such in the VS Code marketplace.

Do not merge before the last beta release has gone out.