### PR TITLE
Remove beta note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 1Password for VS Code provides you with a set of tools to integrate your development workflow with 1Password, powered by the [1Password CLI](https://developer.1password.com/docs/cli).
 
-**This extension is currently in beta.** If you run into issues or have feedback, please [file an issue](https://github.com/1Password/op-vscode/issues/new).
-
 ## Quick start
 
 ⚡️ This quick start guide will get you up and running with the extension.


### PR DESCRIPTION
This PR removes the beta note from the README, which will also reflect in the VS Code marketplace.

Do not merge before the last beta release has gone out.