### PR TITLE
Set up workflow to automatically publish release on new tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish extension
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: yarn install --frozen-lockfile
+      - name: Publish to Visual Studio Marketplace
+        id: publishToVsm
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          yarn: true
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          files: ${{ steps.publishToVsm.outputs.vsixPath }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 This is an extension for Visual Studio Code, please refer to the [Extension API](https://code.visualstudio.com/api) documentation.
 
-Requires [Node](https://nodejs.org/en/), [VS Code](https://code.visualstudio.com/), and [vsce](https://github.com/microsoft/vscode-vsce) installed globally.
+Requires [Node](https://nodejs.org/en/) and [VS Code](https://code.visualstudio.com/).
 
 ### Dependencies
 
@@ -70,27 +70,35 @@ yarn test -t="returns the custom fields"
 
 ## Distribution
 
-### Building & Packaging
+### Publishing the extension
 
-When you want to build and package up the extension for creating a release, run the following:
+We have a Workflow set up to automatically create a new release of the extension on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=1Password.op-vscode) and [GitHub](https://github.com/1Password/op-vscode/releases) whenever a new version tag is pushed.
+
+You should only need to do the following on the `main` branch:
+
+```shell
+# Replace VERSION with the version you are bumping to
+yarn version --new-version VERSION && git push
+```
+
+This will:
+
+1. Update the `version` property in `package.json`
+2. Commit this version change
+3. Create a new version tag
+4. Push the commit and tag to the remote
+
+Afterward the Workflow will take over, publishing the extension's new version to the VS Code Marketplace and creating a new GitHub Release.
+
+### Manual builds
+
+If you need to build and package up the extension for manual distribution outside of regular publishing, first install [vsce](https://github.com/microsoft/vscode-vsce) globally, and then run the following:
 
 ```shell
 vsce package
 ```
 
 This will run `yarn build` to create a minified version of the extension, and then package it up into a file called `op-vscode-[version].vsix`. This is just a ZIP file with a fancy extension, but with it anyone can install the extension manually by going to the Extension panel, opening the context menu, and clicking "Install from VSIX...".
-
-### Publishing
-
-To publish a new version of the extension, first make sure you are logged into the publisher account used for publishing new releases via `vsce login 1Password`.
-
-Bump up the version in `package.json`, then run:
-
-```shell
-vsce publish
-```
-
-This will create a new version of the extension on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=1Password.op-vscode).
 
 ## Acknowledgments
 


### PR DESCRIPTION
Right now when we want to put out a new version we need to:

1. Update the version in `package.json`, commit it
2. Create a new tag with the new version
3. Push to the remote
4. Publish the extension to the VS Code Marketplace locally (`vsce publish`)
5. Create a new VSIX file locally (`vsce package`)
6. Create a new Release with the VSIX file

Let's make this easier!

First, I realized Yarn has `yarn version`, so I've updated the `README` to document this and it'll take care of the first three steps.

Next I've added a new Workflow that takes care of the last three steps and does the following:

- Activates whenever a new tag beginning with a `v` is pushed.
- Sets the [GITHUB_TOKEN permission](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret) such that it can write to the repo (this is used for the releases action)
- Sets up Node, Yarn, etc.
- Uses the [HaaLeo/publish-vscode-extension](https://github.com/HaaLeo/publish-vscode-extension) GitHub Action to create a new release for the VS Code Marketplace.
  - Uses a VS_MARKETPLACE_TOKEN secret I've set up
  - Takes care of building and packaging everything
- Uses the [softprops/action-gh-release](https://github.com/softprops/action-gh-release) GitHub Action to create a new GitHub Release in the repo
  - Defaults title of Release to tag name
  - The previous action provides us with a path to the VSIX file it just published so that we can attach it as a file to the Release