### PR TITLE
Add 'Publish to Open VSX Registry' step to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
       - name: Publish to Visual Studio Marketplace
         id: publishToVsm
         uses: HaaLeo/publish-vscode-extension@v1


### PR DESCRIPTION
Closes #33 

This PR updates the publish workflow to publish our extension to the Open VSX registry. We are already [set up on the registry](https://open-vsx.org/extension/1Password/op-vscode), and this step references a `OPEN_VSX_TOKEN` secret, which exists in this repo.