### PR TITLE
Reduce false positives when detecting secrets

### DIFF
--- a/src/secret-detection/parsers/dotenv.ts
+++ b/src/secret-detection/parsers/dotenv.ts
@@ -44,7 +44,7 @@ export default class DotEnvParser extends Parser {
 
 			// Start by trying to find an exact pattern match
 			// If one is found, use it and continue to next line
-			const regexpMatch = matchFromRegexp(lineValue);
+			const regexpMatch = matchFromRegexp(fieldValue);
 			const suggestion = regexpMatch?.suggestion || suggestionFromKey(keyValue);
 
 			if (suggestion) {

--- a/src/secret-detection/parsers/generic.ts
+++ b/src/secret-detection/parsers/generic.ts
@@ -13,7 +13,7 @@ export default class GenericParser extends Parser {
 			lineNumber++
 		) {
 			const lineValue = this.document.lineAt(lineNumber).text;
-			const regexpMatch = matchFromRegexp(lineValue);
+			const regexpMatch = matchFromRegexp(lineValue, true);
 
 			if (!regexpMatch) {
 				continue;

--- a/src/secret-detection/parsers/index.test.ts
+++ b/src/secret-detection/parsers/index.test.ts
@@ -12,6 +12,13 @@ describe("findBrand", () => {
 	it("finds a known brand name in a string", () => {
 		const brand = sample(BRANDS);
 		expect(findBrand(`some ${brand} text`)).toEqual(brand);
+		expect(findBrand(`some-${brand}-text`)).toEqual(brand);
+		expect(findBrand(`some_${brand}_text`)).toEqual(brand);
+	});
+
+	it("bails if brand doesn't have adequate spacer", () => {
+		const brand = sample(BRANDS);
+		expect(findBrand(`some${brand}text`)).toBeUndefined();
 	});
 });
 
@@ -68,6 +75,12 @@ describe("suggestionFromKey", () => {
 			field: "secret key",
 			type: "concealed",
 		});
+	});
+
+	it("bails if hinted key doesn't have adequate spacer", () => {
+		expect(suggestionFromKey("stripe secretkey")).toBeUndefined();
+		// this was a real false positive, "password"
+		expect(suggestionFromKey("@1password/front-end-style")).toBeUndefined();
 	});
 });
 

--- a/src/secret-detection/parsers/index.test.ts
+++ b/src/secret-detection/parsers/index.test.ts
@@ -28,10 +28,27 @@ describe("matchFromRegexp", () => {
 		expect(match).toBeUndefined();
 	});
 
+	const exampleStripeKey = "sk_test_Hrs6SAopgFPF0bZXSN3f6ELN";
+	const mixedStripeKey = `${exampleStripeKey} some other value`;
+
 	it("returns a match based on a known regexp pattern", () => {
-		const exampleStripeKey = "sk_test_Hrs6SAopgFPF0bZXSN3f6ELN";
 		const suggestion = getPatternSuggestion("stripe-sk");
 		const match = matchFromRegexp(exampleStripeKey);
+		expect(match).toEqual({
+			value: exampleStripeKey,
+			index: 0,
+			suggestion,
+		});
+	});
+
+	it("requires the match to be the entire value by default", () => {
+		const match = matchFromRegexp(mixedStripeKey);
+		expect(match).toBeUndefined();
+	});
+
+	it("can match a value that also contains other non-matching characters", () => {
+		const suggestion = getPatternSuggestion("stripe-sk");
+		const match = matchFromRegexp(mixedStripeKey, true);
 		expect(match).toEqual({
 			value: exampleStripeKey,
 			index: 0,
@@ -44,7 +61,7 @@ describe("matchFromRegexp", () => {
 		const brand = "Heroku";
 		const suggestion = getPatternSuggestion("uuid");
 		suggestion.item = brand;
-		const match = matchFromRegexp(`${brand} ${exampleUuid}`);
+		const match = matchFromRegexp(`${brand} ${exampleUuid}`, true);
 		expect(match).toEqual({
 			value: exampleUuid,
 			index: brand.length + 1,

--- a/src/secret-detection/parsers/index.test.ts
+++ b/src/secret-detection/parsers/index.test.ts
@@ -1,4 +1,9 @@
-import { findBrand, matchFromRegexp, suggestionFromKey } from ".";
+import {
+	findBrand,
+	matchFromRegexp,
+	suggestionFromKey,
+	validValueIsolation,
+} from ".";
 import { sample } from "../../../test/utils";
 import { getPatternSuggestion } from "../patterns";
 import { BRANDS } from "../suggestion";
@@ -63,5 +68,48 @@ describe("suggestionFromKey", () => {
 			field: "secret key",
 			type: "concealed",
 		});
+	});
+});
+
+describe("validValueIsolation", () => {
+	const spaceInput = "value test string";
+	const noSpaceInput = "valueteststring";
+	const dashInput = "value-test-string";
+	const underscoreInput = "value_test_string";
+
+	it("returns true if the match is the same as the input", () =>
+		expect(validValueIsolation(spaceInput, spaceInput)).toBe(true));
+
+	it("returns true if the match is a substring of the input, with a following space", () =>
+		expect(validValueIsolation(spaceInput, "value")).toBe(true));
+
+	it("returns true if the match is a substring of the input, with a preceding space", () =>
+		expect(validValueIsolation(spaceInput, "string")).toBe(true));
+
+	it("returns true if the match is a substring of the input, with surrounding space", () =>
+		expect(validValueIsolation(spaceInput, "test")).toBe(true));
+
+	it("returns true if the match is a substring of the input and is separated by dashes", () => {
+		expect(validValueIsolation(dashInput, "value")).toBe(true);
+		expect(validValueIsolation(dashInput, "string")).toBe(true);
+		expect(validValueIsolation(dashInput, "test")).toBe(true);
+	});
+
+	it("returns true if the match is a substring of the input and is separated by underscores", () => {
+		expect(validValueIsolation(underscoreInput, "value")).toBe(true);
+		expect(validValueIsolation(underscoreInput, "string")).toBe(true);
+		expect(validValueIsolation(underscoreInput, "test")).toBe(true);
+	});
+
+	it("returns false if the match is a substring of the input, but has no spacing", () => {
+		expect(validValueIsolation(noSpaceInput, "value")).toBe(false);
+		expect(validValueIsolation(noSpaceInput, "string")).toBe(false);
+		expect(validValueIsolation(noSpaceInput, "test")).toBe(false);
+	});
+
+	it("returns false with mixed separator characters", () => {
+		expect(validValueIsolation("value test-string", "test")).toBe(false);
+		expect(validValueIsolation("value_test-string", "test")).toBe(false);
+		expect(validValueIsolation("value_test string", "test")).toBe(false);
 	});
 });

--- a/src/secret-detection/parsers/index.ts
+++ b/src/secret-detection/parsers/index.ts
@@ -50,7 +50,9 @@ export const validValueIsolation = (input: string, match: string) =>
 	);
 
 export const findBrand = (input: string): string | undefined =>
-	BRANDS.find((brand) => input.toLowerCase().includes(brand.toLowerCase()));
+	BRANDS.find((brand) =>
+		validValueIsolation(input.toLowerCase(), brand.toLowerCase()),
+	);
 
 export const matchFromRegexp = (input: string): MatchDetail | undefined => {
 	const patternMatch = patternsRegex.exec(input);
@@ -85,7 +87,7 @@ export const suggestionFromKey = (input: string): Suggestion => {
 	const extractedBrand = findBrand(input);
 	const extractedKey = SECRET_KEY_HINT.exec(input)?.[0];
 
-	if (!extractedKey) {
+	if (!extractedKey || !validValueIsolation(input, extractedKey)) {
 		return;
 	}
 

--- a/src/secret-detection/parsers/index.ts
+++ b/src/secret-detection/parsers/index.ts
@@ -54,7 +54,10 @@ export const findBrand = (input: string): string | undefined =>
 		validValueIsolation(input.toLowerCase(), brand.toLowerCase()),
 	);
 
-export const matchFromRegexp = (input: string): MatchDetail | undefined => {
+export const matchFromRegexp = (
+	input: string,
+	partial = false,
+): MatchDetail | undefined => {
 	const patternMatch = patternsRegex.exec(input);
 	if (!patternMatch) {
 		return;
@@ -63,6 +66,13 @@ export const matchFromRegexp = (input: string): MatchDetail | undefined => {
 	let suggestion: Suggestion;
 	const value = patternMatch[0];
 	const index = patternMatch.index;
+
+	if (
+		(!partial && input !== value) ||
+		(partial && !validValueIsolation(input, value))
+	) {
+		return;
+	}
 
 	// We know that the value matches one of the patterns,
 	// now let's find out which one

--- a/src/secret-detection/parsers/index.ts
+++ b/src/secret-detection/parsers/index.ts
@@ -39,6 +39,16 @@ const patternsRegex = combineRegexp(
 	...patternSuggestions.map((detection) => new RegExp(detection.pattern)),
 );
 
+export const validValueIsolation = (input: string, match: string) =>
+	input === match ||
+	[" ", "\\-", "_"].some((spacer) =>
+		combineRegexp(
+			new RegExp(`${spacer}${match}$`),
+			new RegExp(`^${match}${spacer}`),
+			new RegExp(`${spacer}${match}${spacer}`),
+		).test(input),
+	);
+
 export const findBrand = (input: string): string | undefined =>
 	BRANDS.find((brand) => input.toLowerCase().includes(brand.toLowerCase()));
 


### PR DESCRIPTION
We had a couple instances where VS Code would incorrectly recommend saving in 1Password or detect brands:

- When a credit card pattern was found in a hash value: `e5f89039e4675196870326fdfa4c23ee4e29103ec4a1d1187e44b` contains `4675196870326`
- When there was no spacer around a brand: `JAWS_TOKEN` matches on `token`, but also incorrectly matches `aws`
- When there was no spacer around a secret keyword: `@1password/front-end-style` contains `password`.

This PR addresses these cases by ensuring that brands, secret keywords, and regexp-matched patterns are correctly isolated by space, underscore, or dashes.

{ opvs!59 }