### PR TITLE
Start passing in op-js user agent details

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
 		]
 	},
 	"dependencies": {
-		"@1password/op-js": "^0.1.2",
+		"@1password/op-js": "^0.1.5",
 		"json-to-ast": "^2.1.0",
 		"open": "^8.4.0",
 		"timeago.js": "^4.0.2",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,7 +1,9 @@
 import * as opjs from "@1password/op-js";
+import { version } from "../package.json";
 import { window } from "../test/vscode-mock";
 import { CLI, createErrorHandler } from "./cli";
 import { logger } from "./logger";
+import { semverToInt } from "./utils";
 
 const cli = new CLI();
 const goodCommand = jest.fn().mockReturnValue("good");
@@ -13,6 +15,7 @@ const badCommand = jest.fn().mockImplementation(() => {
 jest.mock("@1password/op-js", () => ({
 	// @ts-expect-error ok bud
 	...jest.requireActual("@1password/op-js"),
+	setClientInfo: jest.fn(),
 	validateCli: jest.fn(),
 }));
 
@@ -47,6 +50,18 @@ describe("CLI", () => {
 	beforeAll(() => {
 		cli.valid = true;
 	});
+
+	describe("constructor", () => {
+		it("sets op-js user agent info", () => {
+			new CLI();
+			expect(opjs.setClientInfo).toHaveBeenCalledWith({
+				build: semverToInt(version),
+				id: "VSC",
+				name: "1Password for VS Code",
+			});
+		});
+	});
+
 	describe("execute", () => {
 		it("guards against execution when cli is invalid", async () => {
 			cli.valid = false;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,10 @@
-import { validateCli } from "@1password/op-js";
+import { setClientInfo, validateCli } from "@1password/op-js";
 import { default as open } from "open";
 import { window } from "vscode";
+import { version } from "../package.json";
 import { REGEXP, URLS } from "./constants";
 import { logger } from "./logger";
-import { endWithPunctuation } from "./utils";
+import { endWithPunctuation, semverToInt } from "./utils";
 
 export const createErrorHandler =
 	(showError: boolean) => async (error: Error) => {
@@ -31,6 +32,14 @@ export const createErrorHandler =
 
 export class CLI {
 	valid = false;
+
+	public constructor() {
+		setClientInfo({
+			name: "1Password for VS Code",
+			id: "VSC",
+			build: semverToInt(version),
+		});
+	}
 
 	public async execute<TReturn>(
 		command: () => TReturn,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,8 +6,18 @@ import {
 	formatTitle,
 	isInRange,
 	maskString,
+	semverToInt,
 	titleCase,
 } from "./utils";
+
+describe("semverToInt", () => {
+	it("converts a semver string to build number", () => {
+		expect(semverToInt("0.1.2")).toBe("000102");
+		expect(semverToInt("1.2.3")).toBe("010203");
+		expect(semverToInt("12.2.39")).toBe("120239");
+		expect(semverToInt("2.1.284")).toBe("0201284");
+	});
+});
 
 describe("titleCase", () => {
 	it("converts a string to title case", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,11 @@
 import { REGEXP } from "./constants";
 
+export const semverToInt = (input: string) =>
+	input
+		.split(".")
+		.map((n) => n.padStart(2, "0"))
+		.join("");
+
 export const titleCase = (value: string): string =>
 	value.replace(
 		/\w\S*/g,

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,10 +26,10 @@
     stylelint "^14.0.0"
     stylelint-scss "^4.0.0"
 
-"@1password/op-js@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@1password/op-js/-/op-js-0.1.2.tgz#0e5c745d2b1624411099cbf7184125ca46736cd6"
-  integrity sha512-QObuBFv4eEEPFgcY47b+AiIptUXIiiG+J2Z+8YcJkLBuPpjuhd0P1zG76HxJWOxekG+2ivTLks7YHzi+EtWpbA==
+"@1password/op-js@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@1password/op-js/-/op-js-0.1.5.tgz#0ca2256da3fef9ef94a141f2af8bc609ab57f8f2"
+  integrity sha512-YcHW9MdPzIE2hcwx5Xv0/6N3ftOf/wzeJIThA5sFxWypw8zTaLuSKkNr0Q2VOryhVcCEuiFCV8XU7asBFirscQ==
   dependencies:
     lookpath "^1.2.2"
     semver "^7.3.6"


### PR DESCRIPTION
1Password CLI will start collecting simple usage information via user agent. To support this op-vscode ([by way of op-js](https://github.com/1Password/op-js/pull/37)) is going to specify a few environment variables for the CLI to pick up:

- `OP_INTEGRATION_NAME`: "1Password for VS Code"
- `OP_INTEGRATION_ID`: "VSC"
- `OP_INTEGRATION_BUILDNUMBER` (numeric)

It does this by calling the op-js helper `setClientInfo` and passing this information in.