### PR TITLE
Support item creation across CLI versions, better error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
 		]
 	},
 	"dependencies": {
-		"@1password/op-js": "^0.1.5",
+		"@1password/op-js": "^0.1.7",
 		"json-to-ast": "^2.1.0",
 		"open": "^8.4.0",
 		"timeago.js": "^4.0.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { setClientInfo, validateCli } from "@1password/op-js";
 import { default as open } from "open";
 import { window } from "vscode";
 import { version } from "../package.json";
-import { REGEXP, URLS } from "./constants";
+import { URLS } from "./constants";
 import { logger } from "./logger";
 import { endWithPunctuation, semverToInt } from "./utils";
 
@@ -11,13 +11,8 @@ export const createErrorHandler =
 		const errorPrefix = "Error executing CLI command";
 
 		let errorMessage = errorPrefix;
-		const responseMessage = error.message
-			.replace(/[\n\r]/g, "")
-			.replace(/(\s{2,}|\t)/g, " ")
-			.match(REGEXP.CLI_ERROR);
-
-		if (responseMessage) {
-			errorMessage += `: ${endWithPunctuation(responseMessage[1])}`;
+		if (error.message) {
+			errorMessage += `: ${endWithPunctuation(error.message)}`;
 		}
 
 		// TODO: update to log error code when JS wrapper starts providing it
@@ -78,7 +73,7 @@ export class CLI {
 				throw error;
 			}
 
-			if (error.message.includes("locate op CLI")) {
+			if (error.message.includes("executable")) {
 				this.valid = false;
 				const openInstallDocs = "Open installation documentation";
 
@@ -92,7 +87,7 @@ export class CLI {
 				}
 
 				return;
-			} else if (error.message.includes("does not satisfy version")) {
+			} else {
 				this.valid = false;
 
 				const openUpgradeDocs = "Open upgrade documentation";

--- a/src/constants.test.ts
+++ b/src/constants.test.ts
@@ -10,14 +10,6 @@ describe("COMMANDS", () => {
 });
 
 describe("REGEXP", () => {
-	describe("CLI_ERROR", () => {
-		it("matches an error produced by the CLI", () => {
-			const message = "[ERROR] 2022/06/01 13:08:57 unknown command";
-			expect(message).toMatchRegExp(REGEXP.CLI_ERROR);
-			expect(message).toHaveRegExpParts(REGEXP.CLI_ERROR, "unknown command");
-		});
-	});
-
 	describe("SECRET_REFERENCE", () => {
 		it("matches 3 and 4-part secret references", () => {
 			const threePartRef = "op://vault/item/field";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,6 @@ export const URLS = {
 };
 
 export const REGEXP = {
-	CLI_ERROR: /\[ERROR] \d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} (.+)/,
 	SECRET_REFERENCE:
 		/op:\/\/([\w -]+)\/([\w -]+)\/([\w -]+)(?:\/([\w -]+))?(?<! )/,
 	CAPITALIZED_WORDS: /(api|aws|id|uuid|url)/gi,

--- a/src/items.ts
+++ b/src/items.ts
@@ -205,6 +205,11 @@ export class Items {
 			}),
 		);
 
+		// If the vault is locked this will be undefined
+		if (!vaultItem) {
+			return;
+		}
+
 		vaultItem = await this.core.cli.execute<Item>(() => item.get(vaultItem.id));
 
 		if (!vaultItem) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -202,6 +202,12 @@ export class Setup {
 			vault.list(),
 		);
 
+		// You cannot have 0 vaults, but if you don't authorize the
+		// vault lookup this value will be undfined.
+		if (!vaultsList) {
+			return;
+		}
+
 		const response = await window.showQuickPick(
 			vaultsList.map((vault) => vault.name).sort(),
 			{

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,10 +26,10 @@
     stylelint "^14.0.0"
     stylelint-scss "^4.0.0"
 
-"@1password/op-js@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@1password/op-js/-/op-js-0.1.5.tgz#0ca2256da3fef9ef94a141f2af8bc609ab57f8f2"
-  integrity sha512-YcHW9MdPzIE2hcwx5Xv0/6N3ftOf/wzeJIThA5sFxWypw8zTaLuSKkNr0Q2VOryhVcCEuiFCV8XU7asBFirscQ==
+"@1password/op-js@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@1password/op-js/-/op-js-0.1.7.tgz#b0a343b685fb20b09df9db925207309e8b87e77b"
+  integrity sha512-csTAdBuNUKknHt6tdIfTmm7oPzo1jA40ag7n7G82HRplJj3av3Hz9GZFnBzIpgbFITWSIwcGCmBBIlA/B7CN3Q==
   dependencies:
     lookpath "^1.2.2"
     semver "^7.3.6"


### PR DESCRIPTION
Closes #69 

Users who use >= 2.6.2 of 1Password CLI with the extension are encountering errors when creating/saving an item.

This PR does the following:
- Updates to v0.1.7 of `op-js`, which now correctly handles item creation before and after v2.6.2 of the CLI, where creation logic was modified.
- Updates how we handle errors coming from the CLI. Specifically `op-js` now handles parsing the error response from CLI, so we don't need to.
- Handles a couple other instances where a response value from a CLI command was undefined.