### PR TITLE
Secret detection: handle surrounding quotes, expand AST parser usage

### DIFF
--- a/src/language-providers/code-lens.test.ts
+++ b/src/language-providers/code-lens.test.ts
@@ -4,7 +4,27 @@ import DotEnvParser, * as dotEnvParser from "../secret-detection/parsers/dotenv"
 import GenericParser, * as genericParser from "../secret-detection/parsers/generic";
 import JsonParser, * as jsonParser from "../secret-detection/parsers/json";
 import YamlParser, * as yamlParser from "../secret-detection/parsers/yaml";
-import { provideCodeLenses } from "./code-lens";
+import { documentMatcher, provideCodeLenses } from "./code-lens";
+
+describe("documentMatcher", () => {
+	const languageDocument = createDocument([], "properties", "test.js");
+	const extensionDocument = createDocument([], "plaintext", "config.env");
+
+	it("should match the document based on its language", () => {
+		const matchDocument = documentMatcher(languageDocument);
+		expect(matchDocument(["dotenv", "properties"], [])).toBe(true);
+	});
+
+	it("should match the document based on its file extension", () => {
+		const matchDocument = documentMatcher(extensionDocument);
+		expect(matchDocument([], ["env"])).toBe(true);
+	});
+
+	it("should not match documents that don't satisfy the file name or language id", () => {
+		const matchDocument = documentMatcher(languageDocument);
+		expect(matchDocument(["yaml"], ["yaml", "yml"])).toBe(false);
+	});
+});
 
 describe("provideCodeLenses", () => {
 	it("returns an empty array if the config is disabled", () => {

--- a/src/language-providers/code-lens.ts
+++ b/src/language-providers/code-lens.ts
@@ -8,18 +8,24 @@ import GenericParser from "../secret-detection/parsers/generic";
 import JsonParser from "../secret-detection/parsers/json";
 import YamlParser from "../secret-detection/parsers/yaml";
 
+export const documentMatcher =
+	(document: TextDocument) => (ids: string[], exts: string[]) =>
+		ids.includes(document.languageId) ||
+		exts.some((ext) => document.fileName.endsWith(`.${ext}`));
+
 export const provideCodeLenses = (document: TextDocument): CodeLens[] => {
 	if (!config.get<boolean>(ConfigKey.EditorSuggestStorage)) {
 		return;
 	}
 
+	const matchDocument = documentMatcher(document);
 	let parser: Parser;
 
-	if (document.languageId === "dotenv") {
+	if (matchDocument(["dotenv", "properties"], ["env"])) {
 		parser = new DotEnvParser(document);
-	} else if (document.languageId === "yaml") {
+	} else if (matchDocument(["yaml"], ["yaml", "yml"])) {
 		parser = new YamlParser(document);
-	} else if (["json", "jsonc"].includes(document.languageId)) {
+	} else if (matchDocument(["json", "jsonc"], ["json"])) {
 		parser = new JsonParser(document);
 	} else {
 		parser = new GenericParser(document);

--- a/src/secret-detection/parsers/index.test.ts
+++ b/src/secret-detection/parsers/index.test.ts
@@ -106,6 +106,8 @@ describe("validValueIsolation", () => {
 	const noSpaceInput = "valueteststring";
 	const dashInput = "value-test-string";
 	const underscoreInput = "value_test_string";
+	const singleQuoteInput = `'${spaceInput}'`;
+	const doubleQuoteInput = `"${spaceInput}"`;
 
 	it("returns true if the match is the same as the input", () =>
 		expect(validValueIsolation(spaceInput, spaceInput)).toBe(true));
@@ -141,5 +143,10 @@ describe("validValueIsolation", () => {
 		expect(validValueIsolation("value test-string", "test")).toBe(false);
 		expect(validValueIsolation("value_test-string", "test")).toBe(false);
 		expect(validValueIsolation("value_test string", "test")).toBe(false);
+	});
+
+	it("returns true if the match is a substring and is surrounded by quotes", () => {
+		expect(validValueIsolation(singleQuoteInput, spaceInput)).toBe(true);
+		expect(validValueIsolation(doubleQuoteInput, spaceInput)).toBe(true);
 	});
 });

--- a/src/secret-detection/parsers/index.ts
+++ b/src/secret-detection/parsers/index.ts
@@ -40,7 +40,15 @@ const patternsRegex = combineRegexp(
 );
 
 export const validValueIsolation = (input: string, match: string) =>
+	// the match is identical to the input we're testing against
 	input === match ||
+	// the match is surrounded by quotes
+	["'", '"'].some((quote) =>
+		new RegExp(`${quote}${match}${quote}`).test(input),
+	) ||
+	// the match is surrounded by, preceded by at the end of
+	// a line, or followed by at the beginning of a line, a
+	// space, dash, or underscore
 	[" ", "\\-", "_"].some((spacer) =>
 		combineRegexp(
 			new RegExp(`${spacer}${match}$`),

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -12,6 +12,7 @@ export const sample = <T>(items: T[]): T =>
 export const createDocument = (
 	lines: string | string[] = [],
 	languageId = "plaintext",
+	fileName = "test.txt",
 ) => {
 	const content = Array.isArray(lines) ? lines : [lines];
 	return {
@@ -20,5 +21,6 @@ export const createDocument = (
 		getText: jest.fn(() => content.join("\n")),
 		positionAt: jest.fn(),
 		languageId,
+		fileName,
 	} as unknown as TextDocument;
 };


### PR DESCRIPTION
We've identified a couple ways secret detection can be improved. This PR adds them:

**Allow language-specific parsers to be applied in more scenarios.**

Currently we only check the language ID of a file to determine if an AST parser should be applied. Specifically in `.env` file cases, support for the specific language ID we were checking (`dotenv`) requires the installation of another extension, but a user might not have it installed. So now we're also going allow the file extension to be used as a qualifier for applying an AST parser. For example, a file ending in `.env` will now use the DotEnv parser.

**Account for secrets wrapped in quotes.**

When looking for secrets we check before and after the secret to make sure that it's not part of a larger string in order to avoid false positives. However, this meant that it excluded secrets if they were surrounded by quotation marks.

That means this wouldn't be detected:

```js
const secret = "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";
```

But this would:

```js
const secret = " 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 ";
```

We're now going to allow for secret detection if the matched secret is surrounded by single or double quotes.