### PR TITLE
Update to v0.1.8 of op-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
 		]
 	},
 	"dependencies": {
-		"@1password/op-js": "^0.1.7",
+		"@1password/op-js": "^0.1.8",
 		"json-to-ast": "^2.1.0",
 		"open": "^8.4.0",
 		"timeago.js": "^4.0.2",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -109,18 +109,43 @@ describe("CLI", () => {
 		});
 
 		it("sets valid to false and warns when cli could not be located", async () => {
+			const error = new opjs.ValidationError("not-found");
 			jest.spyOn(opjs, "validateCli").mockImplementation(() => {
-				throw new Error("locate op CLI");
+				throw error;
 			});
 			await cli.validate();
 			expect(cli.valid).toBe(false);
 		});
 
 		it("sets valid to false and warns when cli is incorrect version", async () => {
+			const error = new opjs.ValidationError("version");
 			jest.spyOn(opjs, "validateCli").mockImplementation(() => {
-				throw new Error("does not satisfy version");
+				throw error;
 			});
 			await cli.validate();
+			expect(cli.valid).toBe(false);
+		});
+
+		it("re-throws a caught error that is not a ValidationError", async () => {
+			const error = new Error("foo");
+			jest.spyOn(opjs, "validateCli").mockImplementation(() => {
+				throw error;
+			});
+			await expect(async () => await cli.validate()).rejects.toThrow(
+				error.message,
+			);
+			expect(cli.valid).toBe(false);
+		});
+
+		it("re-throws a caught ValidationError with an unknown type", async () => {
+			// @ts-expect-error testing invalid type
+			const error = new opjs.ValidationError("foo");
+			jest.spyOn(opjs, "validateCli").mockImplementation(() => {
+				throw error;
+			});
+			await expect(async () => await cli.validate()).rejects.toThrow(
+				error.message,
+			);
 			expect(cli.valid).toBe(false);
 		});
 	});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { setClientInfo, validateCli } from "@1password/op-js";
+import { setClientInfo, validateCli, ValidationError } from "@1password/op-js";
 import { default as open } from "open";
 import { window } from "vscode";
 import { version } from "../package.json";
@@ -69,12 +69,13 @@ export class CLI {
 		try {
 			await validateCli();
 		} catch (error: any) {
-			if (!(error instanceof Error)) {
+			this.valid = false;
+
+			if (!(error instanceof ValidationError)) {
 				throw error;
 			}
 
-			if (error.message.includes("executable")) {
-				this.valid = false;
+			if (error.type === "not-found") {
 				const openInstallDocs = "Open installation documentation";
 
 				const response = await window.showErrorMessage(
@@ -87,9 +88,7 @@ export class CLI {
 				}
 
 				return;
-			} else {
-				this.valid = false;
-
+			} else if (error.type === "version") {
 				const openUpgradeDocs = "Open upgrade documentation";
 
 				const response = await window.showErrorMessage(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,35 +75,36 @@ export class CLI {
 				throw error;
 			}
 
-			if (error.type === "not-found") {
-				const openInstallDocs = "Open installation documentation";
+			switch (error.type) {
+				case "not-found":
+					const openInstallDocs = "Open installation documentation";
 
-				const response = await window.showErrorMessage(
-					"CLI is not installed. Please install it to use 1Password for VS Code.",
-					openInstallDocs,
-				);
+					if (
+						(await window.showErrorMessage(
+							"CLI is not installed. Please install it to use 1Password for VS Code.",
+							openInstallDocs,
+						)) === openInstallDocs
+					) {
+						await open(URLS.CLI_INSTALL_DOCS);
+					}
 
-				if (response === openInstallDocs) {
-					await open(URLS.CLI_INSTALL_DOCS);
-				}
+					break;
+				case "version":
+					const openUpgradeDocs = "Open upgrade documentation";
 
-				return;
-			} else if (error.type === "version") {
-				const openUpgradeDocs = "Open upgrade documentation";
+					if (
+						(await window.showErrorMessage(
+							`${error.message}. Please upgrade to the latest version to use 1Password for VS Code.`,
+							openUpgradeDocs,
+						)) === openUpgradeDocs
+					) {
+						await open(URLS.CLI_UPGRADE_DOCS);
+					}
 
-				const response = await window.showErrorMessage(
-					`${error.message}. Please upgrade to the latest version to use 1Password for VS Code.`,
-					openUpgradeDocs,
-				);
-
-				if (response === openUpgradeDocs) {
-					await open(URLS.CLI_UPGRADE_DOCS);
-				}
-
-				return;
+					break;
+				default:
+					throw error;
 			}
-
-			throw error;
 		}
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,10 +26,10 @@
     stylelint "^14.0.0"
     stylelint-scss "^4.0.0"
 
-"@1password/op-js@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@1password/op-js/-/op-js-0.1.7.tgz#b0a343b685fb20b09df9db925207309e8b87e77b"
-  integrity sha512-csTAdBuNUKknHt6tdIfTmm7oPzo1jA40ag7n7G82HRplJj3av3Hz9GZFnBzIpgbFITWSIwcGCmBBIlA/B7CN3Q==
+"@1password/op-js@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@1password/op-js/-/op-js-0.1.8.tgz#621af1e608490ffa2b90acee748efc9666316c49"
+  integrity sha512-36Y4TXI0tBwDe6672CHhHvZErf1mgH0/AVt0woCZByOBM5PPUq/CSxAHKilKZrK8vpsTBA68MxV8q2RUExzfsg==
   dependencies:
     lookpath "^1.2.2"
     semver "^7.3.6"


### PR DESCRIPTION
This PR updates our op-js version to 0.1.8, which includes the following:

- Allows inspection of `ValidationError` errors and its specific type for better CLI validation (now we don't have to rely on an arbitrary error substring)
- Fixes an issue where versions 2.6.2 of 1Password CLI broke the "Preview with Secrets" command

Closes #81 