### PR TITLE
feat: Add GitLab token pattern to secret detection

### DIFF
--- a/src/secret-detection/patterns.ts
+++ b/src/secret-detection/patterns.ts
@@ -168,6 +168,13 @@ export const VALUE_PATTERNS: PatternSuggestion[] = [
 		pattern: "(gh[pous]_[a-zA-Z0-9]{36}|ghr_[a-zA-Z0-9]{76})",
 	},
 	{
+		id: "gitlab-token",
+		item: "GitLab",
+		field: "token",
+		type: "concealed",
+		pattern: "gl(?:pat|oas|dt|rt|cbt)-[a-zA-Z0-9-_]{20}",
+	},
+	{
 		id: "hubspot-webhook",
 		item: "HubSpot",
 		field: "webhook",


### PR DESCRIPTION
- More Information about further `GitLab`-tokens can be found at: https://docs.gitlab.com/security/tokens/#token-prefixes
- Fixes: _Support for `gitlab-token` in VS Code Plugin for Secure Token Management_ #211